### PR TITLE
Procedure implementation

### DIFF
--- a/Project2/GuardedCommands/CodeGen.fs
+++ b/Project2/GuardedCommands/CodeGen.fs
@@ -116,7 +116,11 @@ module CodeGeneration =
 
        | Return (Some e) -> CE vEnv fEnv e @ [RET (snd vEnv)]
 
-       | Return None     -> failwith "CS: procedures not supported"
+       | Return None     -> [RET (snd vEnv - 1)]
+
+       | Call(f, es) -> let (label, _, _) = Map.find f fEnv
+                        List.collect (CE vEnv fEnv) es
+                        @ [CALL (List.length es, label); INCSP -1]
 
        | _                -> failwith "CS: this statement is not supported yet"
 

--- a/Project2/GuardedCommands/Lexer.fsl
+++ b/Project2/GuardedCommands/Lexer.fsl
@@ -22,6 +22,7 @@ let keyword s =
     | "false"     -> BOOL(false)
     | "function"  -> FUNCTION
     | "return"    -> RETURN
+    | "procedure" -> PROCEDURE
     | _           -> NAME s  
 }
 

--- a/Project2/GuardedCommands/Parser.fsy
+++ b/Project2/GuardedCommands/Parser.fsy
@@ -11,7 +11,7 @@ open GuardedCommands.Frontend.AST
 %token IF FI DO OD BEGIN END 
 %token COMMA COLON SEMI BAR TO
 %token NEG PLUS MINUS TIMES AND CON EQ LE GE LT GT NEQ
-%token PRINT ASG SKIP ABORT FUNCTION RETURN
+%token PRINT ASG SKIP ABORT FUNCTION RETURN PROCEDURE
 %token EOF
 %token HIGH
 
@@ -54,6 +54,7 @@ Typ:
 
 Dec: 
     FUNCTION NAME LP DecL RP COLON Typ EQ Stm     { FunDec(Some($7), $2, $4, $9 )} 
+  | PROCEDURE NAME LP DecL RP EQ Stm              { FunDec(None    , $2, $4, $7 )}
   | NAME COLON Typ                                { VarDec($3,$1) }
 
 DecL: 
@@ -78,6 +79,7 @@ Stm:
   | IF GuardedCommand FI              { Alt $2 }
   | DO GuardedCommand OD              { Do $2  }
   | RETURN ExpOpt                     { Return $2 }
+  | NAME LP ExpL RP                   { Call($1, $3) }
 
 StmL:
                                       { [] } 

--- a/Project2/GuardedCommands/Script.fsx
+++ b/Project2/GuardedCommands/Script.fsx
@@ -87,10 +87,10 @@ List.iter exec ["gcs/Ex7.gc"; "gcs/fact.gc"; "gcs/factRec.gc"; "gcs/factCBV.gc"]
 
 // Test of programs covered by the fourth task (Section 5.4):
 List.iter exec ["gcs/A0.gc"; "gcs/A1.gc"; "gcs/A2.gc"; "gcs/A3.gc"];;
-(*
-// Test of programs covered by the fifth task (Section 6.1):
-List.iter exec ["A4.gc"; "Swap.gc"; "QuickSortV1.gc"];;
 
+// Test of programs covered by the fifth task (Section 6.1):
+List.iter exec ["gcs/A4.gc"; "gcs/Swap.gc"; "gcs/QuickSortV1.gc"];;
+(*
 // Test of programs covered by the fifth task (Section 7.4):
 List.iter exec ["par1.gc"; "factImpPTyp.gc"; "QuickSortV2.gc"; "par2.gc"];;
 


### PR DESCRIPTION
Resolves: #34 

This is almost like functions, the only thing that is a bit weird is that the code RET m always has to have a single v remaining on the stack as a return value. Therefore when returning we call (params length - 1) to let a single character remain and we then remove it. (Code in Call type)